### PR TITLE
Allow all tags on custom metrics

### DIFF
--- a/client.go
+++ b/client.go
@@ -24,7 +24,6 @@ const (
 var routerMetricsKeys = []string{"dyno", "method", "status", "path", "host", "code", "desc", "at"}
 var sampleMetricsKeys = []string{"source"}
 var scalingMetricsKeys = []string{"mailer", "web"}
-var customMetricsKeys = []string{"media_type", "output_type", "path", "version", "name"}
 
 type Client struct {
 	*statsd.Client
@@ -234,12 +233,8 @@ Tags:
 		if strings.Index(k, "tag#") != -1 {
 			if _, err := strconv.Atoi(v.Val); err != nil {
 				m := strings.Replace(strings.Split(k, "tag#")[1], "_", ".", -1)
-				for _, mk := range customMetricsKeys {
-					if m == mk {
-						tags = append(tags, mk+":"+v.Val)
-						continue Tags
-					}
-				}
+				tags = append(tags, m+":"+v.Val)
+				continue Tags
 			}
 		}
 	}


### PR DESCRIPTION
This removes the whitelist that was being used to filter metric tags. With this change all Grove Core metrics can be surfaced in DataDog. The main risk here is cost increases, as separate tag combinations count as entirely different metrics in DataDog.